### PR TITLE
Upgrade ROM-yaml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rom', git: 'https://github.com/rom-rb/rom.git', branch: 'master' do
+  gem 'rom', git: 'https://github.com/rom-rb/rom.git', branch: 'main' do
     gem 'rom-core'
     gem 'rom-changeset'
     gem 'rom-mapper'


### PR DESCRIPTION
ROM-YAML does not work with ROM 5.3.

This change allow it to use the correct branch "main" and stay up to date.
